### PR TITLE
docs: Fix typo in "lock time" in Zk Proof Update settlement.md

### DIFF
--- a/doc/settlement.md
+++ b/doc/settlement.md
@@ -95,6 +95,6 @@ Break down ProofInputs into segments according to SegmentSize, where each segmen
 ## Transfer
 
 1. Each account has two funds pools: the "non-refunded funds pool" and the "refunded funds pool."
-2. The "refunded funds pool" contains funds that users have requested to refund but the lock time (lock time) has not been reached, so it has not yet been returned to the users.
+2. The "refunded funds pool" contains funds that users have requested to refund but the lock-time (lock-time) has not been reached, so it has not yet been returned to the users.
 3. The "refunded funds pool" consists of individual refunds. Each refund has its amount and application time.
 4. When transferring, the system first deducts from the "non-refunded funds pool" and then proceeds in reverse chronological order to deduct from each refund in the "refunded funds pool" as needed.


### PR DESCRIPTION
### Description:

I’ve noticed a small typo in the section **Zk Proof on the Provider Side** where **"lock time"** was written without a hyphen. The correct format should be **"lock-time"** as it’s commonly used as a compound adjective to describe lock time, and adding the hyphen enhances readability.

Here’s the fix:
- **lock-time**: Lock-time
